### PR TITLE
Make the CLI_OPTS runtime overridable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG CLI_OPTS=-Xmx900m
 
 RUN mkdir /app
 RUN mkdir /data
-RUN echo "cd /data && CLI_OPTS='${CLI_OPTS}' /app/hapi-fhir-cli run-server --allow-external-refs --disable-referential-integrity -f ${FHIR} -p \${PORT:-8080}" > /app/cmd
+RUN echo "cd /data && CLI_OPTS='\${CLI_OPTS_OVERRIDE-\$CLI_OPTS}' /app/hapi-fhir-cli run-server --allow-external-refs --disable-referential-integrity -f ${FHIR} -p \${PORT:-8080}" > /app/cmd
 
 # COPY ./hapi-fhir-3.2.0-cli/* /app/
 ADD https://github.com/jamesagnew/hapi-fhir/releases/download/v3.2.0/hapi-fhir-3.2.0-cli.tar.bz2 /tmp/hapi-cli/


### PR DESCRIPTION
With the existing dockerfile, the only way to override the memory settings was at build time, for actual deployments it is more interesting to have easy to change runtime configuration. Builds will not break since the arg is still there.